### PR TITLE
feat/signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,12 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'com.h2database:h2'
 
+    // Security 의 BCrypt 의존성
+    implementation 'org.springframework.security:spring-security-crypto:6.2.1'
+
+    // Validation 의존성
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/filmpass/domain/auth/conroller/AuthController.java
+++ b/src/main/java/com/example/filmpass/domain/auth/conroller/AuthController.java
@@ -1,10 +1,28 @@
 package com.example.filmpass.domain.auth.conroller;
 
+import com.example.filmpass.domain.auth.dto.SignUpRequestDto;
+import com.example.filmpass.domain.auth.service.AuthService;
+import com.example.filmpass.global.common.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/api/auth/signup")
+    public ResponseEntity<ApiResponse<?>> signUp(
+            @Valid @RequestBody SignUpRequestDto requestDto
+    ) {
+
+        return ResponseEntity.ok(authService.signUp(requestDto));
+
+    }
 
 }

--- a/src/main/java/com/example/filmpass/domain/auth/dto/AuthData.java
+++ b/src/main/java/com/example/filmpass/domain/auth/dto/AuthData.java
@@ -1,0 +1,13 @@
+package com.example.filmpass.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class AuthData {
+
+    private final String email;
+    private final String nickname;
+
+}

--- a/src/main/java/com/example/filmpass/domain/auth/dto/SignUpRequestDto.java
+++ b/src/main/java/com/example/filmpass/domain/auth/dto/SignUpRequestDto.java
@@ -1,0 +1,29 @@
+package com.example.filmpass.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+public class SignUpRequestDto {
+
+    @NotBlank(message = "이름을 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+            message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~20자여야 합니다.")
+    private String password;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    private String nickname;
+
+}

--- a/src/main/java/com/example/filmpass/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/filmpass/domain/auth/service/AuthService.java
@@ -1,9 +1,53 @@
 package com.example.filmpass.domain.auth.service;
 
+import com.example.filmpass.domain.auth.dto.AuthData;
+import com.example.filmpass.domain.auth.dto.SignUpRequestDto;
+import com.example.filmpass.domain.user.entity.User;
+import com.example.filmpass.domain.user.repository.UserRepository;
+import com.example.filmpass.global.common.ApiResponse;
+import com.example.filmpass.global.exception.CustomException;
+import com.example.filmpass.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+
+    // 회원가입 로직
+    public ApiResponse<AuthData> signUp(SignUpRequestDto requestDto) {
+
+        // 저장할 값 꺼내기
+        String name = requestDto.getName();
+        String email = requestDto.getEmail();
+        String rawPassword = requestDto.getPassword();
+        String nickname = requestDto.getNickname();
+
+        // 중복 이메일 체크
+        if(userRepository.existsByEmail(email)) {
+            throw new CustomException(ErrorCode.EMAIL_ALREADY_EXIST);
+        }
+
+        // 중복 닉네임 체크
+        if(userRepository.existsByNickname(nickname)) {
+            throw new CustomException((ErrorCode.NICKNAME_ALREADY_EXIST));
+        }
+
+        String password = passwordEncoder.encode(rawPassword);
+
+        User user = new User(email,password, nickname, name);
+
+        userRepository.save(user);
+
+        AuthData data = new AuthData(user.getEmail(), user.getNickname());
+
+        return ApiResponse.success(data, "회원가입 성공!");
+
+    }
+
 }

--- a/src/main/java/com/example/filmpass/domain/user/entity/User.java
+++ b/src/main/java/com/example/filmpass/domain/user/entity/User.java
@@ -29,4 +29,15 @@ public class User extends BaseEntity {
 
     private Boolean deleted = false; // 삭제 여부 (soft delete)
     private LocalDateTime deletedAt; // 삭제일
+
+    @Column(nullable = false)
+    private String name;
+
+
+    public User(String email, String password, String nickname, String name) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/example/filmpass/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/filmpass/domain/user/repository/UserRepository.java
@@ -4,4 +4,7 @@ import com.example.filmpass.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/example/filmpass/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/filmpass/global/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.example.filmpass.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/example/filmpass/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/filmpass/global/exception/ErrorCode.java
@@ -7,7 +7,11 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다.");
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력 값이 유효하지 않습니다."),
+
+    // Auth
+    EMAIL_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 사용중인 이메일입니다."),
+    NICKNAME_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다.");
 
     private final HttpStatus code;
     private final String message;


### PR DESCRIPTION
closes #5 

회원가입 api 추가
비밀번호 암호화
유효성 검사
이메일, 닉네임 중복검사
BCrypt, Validation 의존성 추가
dto 추가 (AuthData, SignUpRequestDto)
User Entity 에 name 필드 추가
PasswordEncoder 를 빈으로 등록