### PR TITLE
Fix auth,user v1.5

### DIFF
--- a/src/main/java/com/example/filmpass/domain/auth/conroller/AuthController.java
+++ b/src/main/java/com/example/filmpass/domain/auth/conroller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     // 로그인
     @PostMapping("/api/auth/login")
     public ApiResponse login(
-            @RequestBody LoginRequestDto requestDto,
+            @Valid @RequestBody LoginRequestDto requestDto,
             HttpServletResponse response
             ) {
 
@@ -55,7 +55,7 @@ public class AuthController {
     // 권한 변경
     @PatchMapping("/api/auth/{id}")
     public ApiResponse changeRole(
-            @RequestBody RoleRequestDto request,
+            @Valid @RequestBody RoleRequestDto request,
             @PathVariable Long id,
             @AuthenticationPrincipal UserPrincipal principal
             ) {

--- a/src/main/java/com/example/filmpass/domain/auth/dto/LoginRequestDto.java
+++ b/src/main/java/com/example/filmpass/domain/auth/dto/LoginRequestDto.java
@@ -1,11 +1,18 @@
 package com.example.filmpass.domain.auth.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
 public class LoginRequestDto {
 
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+            message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
 

--- a/src/main/java/com/example/filmpass/domain/auth/dto/RoleRequestDto.java
+++ b/src/main/java/com/example/filmpass/domain/auth/dto/RoleRequestDto.java
@@ -1,11 +1,13 @@
 package com.example.filmpass.domain.auth.dto;
 
 import com.example.filmpass.domain.user.enums.UserRole;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class RoleRequestDto {
 
+    @NotBlank(message = "권한을 입력해주세요.")
     private UserRole userRole;
 
 }

--- a/src/main/java/com/example/filmpass/domain/auth/dto/RoleRequestDto.java
+++ b/src/main/java/com/example/filmpass/domain/auth/dto/RoleRequestDto.java
@@ -2,12 +2,13 @@ package com.example.filmpass.domain.auth.dto;
 
 import com.example.filmpass.domain.user.enums.UserRole;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class RoleRequestDto {
 
-    @NotBlank(message = "권한을 입력해주세요.")
+    @NotNull(message = "권한을 입력해주세요.")
     private UserRole userRole;
 
 }

--- a/src/main/java/com/example/filmpass/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/filmpass/domain/auth/service/AuthService.java
@@ -86,6 +86,11 @@ public class AuthService {
             throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
 
+        // 탈퇴한 회원인지 검증
+        if(user.getDeletedAt() != null) {
+            throw new CustomException(ErrorCode.DELETED_USER);
+        }
+
         // RefreshToken 있으면 삭제
         if(refreshTokenRepository.existsByUser_Id(user.getId())) {
             refreshTokenRepository.deleteByUser_Id(user.getId());
@@ -139,15 +144,10 @@ public class AuthService {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        // 본인 권한만 수정하도록 검증
-        if(!user.getId().equals(principal.getUserId())) {
-            throw new CustomException(ErrorCode.CHANGE_BLOCKED);
+        // ADMIN 만 권한변경 가능하도록 검증
+        if(principal.getUserRole() != UserRole.ADMIN) {
+            throw new CustomException(ErrorCode.NOT_ADMIN);
         }
-
-//        // ADMIN 만 권한변경 가능하도록 검증
-//        if(principal.getUserRole() != UserRole.ADMIN) {
-//            throw new CustomException(ErrorCode.NOT_ADMIN);
-//        }
 
         // 입력한 권한이 현재 권한과 같은 Role 인지 검증
         if(principal.getUserRole() == request.getUserRole()) {

--- a/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
@@ -20,11 +20,11 @@ public class UserController {
     // 회원 탈퇴
     @DeleteMapping("/api/users/{id}")
     public ApiResponse deleteUser(
-            @RequestBody PasswordRequestDto requestDto,
+            @RequestHeader("password") String password,
             @PathVariable Long id
             ) {
 
-        userService.deleteUser(id, requestDto);
+        userService.deleteUser(id, password);
 
         return ApiResponse.success(null, "회원 탈퇴가 완료되었습니다.");
 

--- a/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.example.filmpass.domain.user.dto.UserInfoChangeRequestDto;
 import com.example.filmpass.domain.user.service.UserService;
 import com.example.filmpass.global.common.ApiResponse;
 import com.example.filmpass.global.config.UserPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -62,7 +63,7 @@ public class UserController {
 
     @PutMapping("/api/users/{id}")
     public ApiResponse changeUserInfo(
-            @RequestBody UserInfoChangeRequestDto request,
+            @Valid @RequestBody UserInfoChangeRequestDto request,
             @AuthenticationPrincipal UserPrincipal principal,
             @PathVariable Long id) {
 

--- a/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
@@ -23,6 +23,8 @@ public class UserController {
             @PathVariable Long id
             ) {
 
+        userService.deleteUser(id, requestDto);
+
         return ApiResponse.success(null, "회원 탈퇴가 완료되었습니다.");
 
     }

--- a/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
@@ -30,6 +30,7 @@ public class UserController {
 
     }
 
+    // 유저 목록 조회
     @GetMapping("/api/users")
     public ApiResponse getUsers(
             @RequestParam(defaultValue = "1") int page,
@@ -41,6 +42,7 @@ public class UserController {
 
     }
 
+    // 유저 단건 조회
     @GetMapping("/api/users/{id}")
     public ApiResponse getUser(
         @PathVariable Long id,
@@ -51,6 +53,7 @@ public class UserController {
 
     }
 
+    // 내 정보 조회
     @PostMapping("/api/users/me")
     public ApiResponse getMyProfile(
             @RequestBody PasswordRequestDto requestDto,
@@ -61,6 +64,7 @@ public class UserController {
 
     }
 
+    // 내 정보 수정
     @PutMapping("/api/users/{id}")
     public ApiResponse changeUserInfo(
             @Valid @RequestBody UserInfoChangeRequestDto request,

--- a/src/main/java/com/example/filmpass/domain/user/dto/PasswordRequestDto.java
+++ b/src/main/java/com/example/filmpass/domain/user/dto/PasswordRequestDto.java
@@ -1,10 +1,12 @@
 package com.example.filmpass.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class PasswordRequestDto {
 
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
 

--- a/src/main/java/com/example/filmpass/domain/user/dto/UserInfoChangeRequestDto.java
+++ b/src/main/java/com/example/filmpass/domain/user/dto/UserInfoChangeRequestDto.java
@@ -1,13 +1,27 @@
 package com.example.filmpass.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter
 public class UserInfoChangeRequestDto {
 
+
+    @NotBlank(message = "이름을 입력해주세요.")
     private String name;
+
+    @NotBlank(message = "이메일을 입력해주세요.")
+    @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+            message = "올바른 이메일 형식이 아닙니다.")
     private String email;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함한 8~20자여야 합니다.")
     private String password;
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
     private String nickname;
 
 

--- a/src/main/java/com/example/filmpass/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/filmpass/domain/user/repository/UserRepository.java
@@ -14,8 +14,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Page<User> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    Page<User> findAllByDeletedAtIsNotNullOrderByCreatedAtDesc(Pageable pageable);
 
     Optional<User> findByNickname(String nickname);
+
+    Optional<User> findByIdAndDeletedAtIsNotNull(Long id);
 
 }

--- a/src/main/java/com/example/filmpass/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/filmpass/domain/user/repository/UserRepository.java
@@ -14,10 +14,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
 
-    Page<User> findAllByDeletedAtIsNotNullOrderByCreatedAtDesc(Pageable pageable);
+    Page<User> findAllByDeletedAtIsNullOrderByCreatedAtDesc(Pageable pageable);
 
     Optional<User> findByNickname(String nickname);
 
-    Optional<User> findByIdAndDeletedAtIsNotNull(Long id);
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
 
 }

--- a/src/main/java/com/example/filmpass/domain/user/service/UserService.java
+++ b/src/main/java/com/example/filmpass/domain/user/service/UserService.java
@@ -62,7 +62,7 @@ public class UserService {
 
         Pageable pageable = PageRequest.of(page-1, size);
 
-        Page<User> users = userRepository.findAllByDeletedAtIsNotNullOrderByCreatedAtDesc(pageable);
+        Page<User> users = userRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
 
         Page<UserInfoResponseDto> response = users.map(User::pageToDto);
 
@@ -79,7 +79,7 @@ public class UserService {
         }
 
 
-            User user = userRepository.findByIdAndDeletedAtIsNotNull(id)
+            User user = userRepository.findByIdAndDeletedAtIsNull(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         UserDetailsResponseDto response = new UserDetailsResponseDto(

--- a/src/main/java/com/example/filmpass/domain/user/service/UserService.java
+++ b/src/main/java/com/example/filmpass/domain/user/service/UserService.java
@@ -60,9 +60,23 @@ public class UserService {
             throw new CustomException(ErrorCode.NOT_ADMIN);
         }
 
+        // 입력한 페이지가 적절한 값인지 확인
+        if(!(1 <= size && size<= 100)) {
+            throw new CustomException(ErrorCode.INVALID_PAGE_SIZE);
+        }
+
+        if(page < 1) {
+            throw new CustomException(ErrorCode.INVALID_PAGE_NUMBER);
+        }
+
         Pageable pageable = PageRequest.of(page-1, size);
 
         Page<User> users = userRepository.findAllByDeletedAtIsNullOrderByCreatedAtDesc(pageable);
+
+        // 페이지가 비었나 확인
+        if(users.isEmpty() && page > 1) {
+            throw new CustomException(ErrorCode.EMPTY_PAGE);
+        }
 
         Page<UserInfoResponseDto> response = users.map(User::pageToDto);
 

--- a/src/main/java/com/example/filmpass/domain/user/service/UserService.java
+++ b/src/main/java/com/example/filmpass/domain/user/service/UserService.java
@@ -62,7 +62,7 @@ public class UserService {
 
         Pageable pageable = PageRequest.of(page-1, size);
 
-        Page<User> users = userRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Page<User> users = userRepository.findAllByDeletedAtIsNotNullOrderByCreatedAtDesc(pageable);
 
         Page<UserInfoResponseDto> response = users.map(User::pageToDto);
 
@@ -79,7 +79,7 @@ public class UserService {
         }
 
 
-            User user = userRepository.findById(id)
+            User user = userRepository.findByIdAndDeletedAtIsNotNull(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         UserDetailsResponseDto response = new UserDetailsResponseDto(

--- a/src/main/java/com/example/filmpass/domain/user/service/UserService.java
+++ b/src/main/java/com/example/filmpass/domain/user/service/UserService.java
@@ -148,10 +148,21 @@ public class UserService {
         }
 
         // 정보수정하기
-        user.setName(request.getName());
-        user.setEmail(request.getEmail());
-        user.setPassword(passwordEncoder.encode(request.getPassword()));
-        user.setNickname(request.getNickname());
+        if (!user.getName().equals(request.getName())) {
+            user.setName(request.getName());
+        }
+
+        if (!user.getEmail().equals(request.getEmail())) {
+            user.setEmail(request.getEmail());
+        }
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            user.setPassword(passwordEncoder.encode(request.getPassword()));
+        }
+
+        if (!user.getNickname().equals(request.getNickname())) {
+            user.setNickname(request.getNickname());
+        }
 
         userRepository.save(user);
 

--- a/src/main/java/com/example/filmpass/domain/user/service/UserService.java
+++ b/src/main/java/com/example/filmpass/domain/user/service/UserService.java
@@ -29,14 +29,14 @@ public class UserService {
 
     // 회원 탈퇴 로직
     @Transactional
-    public void deleteUser(Long id, PasswordRequestDto requestDto) {
+    public void deleteUser(Long id, String password) {
 
         // 유저 조회
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 비밀번호 검증
-        if(!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+        if(!passwordEncoder.matches(password, user.getPassword())) {
             throw new CustomException(ErrorCode.PASSWORD_MISMATCH);
         }
 

--- a/src/main/java/com/example/filmpass/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/filmpass/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.example.filmpass.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -34,6 +35,8 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable) // 폼 로그인 비활성화
                 .addFilterBefore(jwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class) // jwtFilter 추가
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.GET, "/api/theaters/*", "/api/movies/*"
+                        ,"/api/theaters", "/api/movies").permitAll()
                         .requestMatchers("/api/auth/signup", "/api/auth/login","/").permitAll() // 인증 필요없는 요청들
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/example/filmpass/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/filmpass/global/exception/ErrorCode.java
@@ -30,6 +30,9 @@ public enum ErrorCode {
     NOT_ADMIN(HttpStatus.BAD_REQUEST, "관리자 권한이 없습니다."),
     CHANGE_BLOCKED(HttpStatus.BAD_REQUEST, "본인의 정보만 수정할 수 있습니다."),
     THEATER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST,"극장이 이미 존재합니다."),
+    INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "유효하지 않은 페이지 크기 입니다."),
+    INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "유효하지 않는 페이지 번호 입니다."),
+    EMPTY_PAGE(HttpStatus.NOT_FOUND, "비어있는 페이지 입니다."),
     // Reservation
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "예매 정보를 찾을 수 없습니다."),
     ALREADY_CANCELED(HttpStatus.BAD_REQUEST, "이미 취소된 예매입니다."),


### PR DESCRIPTION
fix
AuthService
  - 권한변경 : 관리자만 권한변경 가능하도록 수정, 타인의 권한을 변경가능 하도록 수정
  - 로그인 : 탈퇴한 회원인지 검증

UserController
  - deleteUser 메서드를 호출하여 요청이 정상적으로 동작하도록 수정
  - deleteUser 가 RequestBody 가 아닌 RequestHeader 를 받도록 수정

UserService
  - 페이지 크기가 음수거나 100 을 넘을 경우 예외처리
  - 페이지 번호가 음수일 경우 예외처리
  - 1번 페이지를 제외한 나머지 페이지가 빈 페이지면 예외처리
  - 변경된 정보만 내 정보 수정에 반영되도록 코드 변경 (쿼리 낭비 방지)

UserRepository
  - 탈퇴한 유저는 조회되지 않도록 쿼리메서드를 변경

ErrorCode
  - 페이지 관련 예외 3개 추가

AuthController, UserController
  - Valid 어노테이션 추가

4개의 요청 Dto 의 필드에 유효성 검증 추가 - LoginRequestDto, RoleRequestDto, PasswordRequestDto, UserInfoChangeRequestDto

SecurityConfig
  - 로그인 안해도 접근 가능 : 극장 목록 조회, 극장 단건 조회, 영화 목록 조회, 영화 단건 조회


closes #134 