### PR TITLE
Feat logging

### DIFF
--- a/src/main/java/com/example/filmpass/domain/auth/conroller/AuthController.java
+++ b/src/main/java/com/example/filmpass/domain/auth/conroller/AuthController.java
@@ -4,6 +4,7 @@ import com.example.filmpass.domain.auth.dto.LoginRequestDto;
 import com.example.filmpass.domain.auth.dto.RoleRequestDto;
 import com.example.filmpass.domain.auth.dto.SignUpRequestDto;
 import com.example.filmpass.domain.auth.service.AuthService;
+import com.example.filmpass.global.aop.TrackUserActionAnnotation;
 import com.example.filmpass.global.common.ApiResponse;
 import com.example.filmpass.global.config.UserPrincipal;
 import jakarta.servlet.http.HttpServletResponse;
@@ -54,6 +55,7 @@ public class AuthController {
 
     // 권한 변경
     @PatchMapping("/api/auth/{id}")
+    @TrackUserActionAnnotation("권한 변경")
     public ApiResponse changeRole(
             @Valid @RequestBody RoleRequestDto request,
             @PathVariable Long id,

--- a/src/main/java/com/example/filmpass/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/example/filmpass/domain/seat/controller/SeatController.java
@@ -51,13 +51,10 @@ public class SeatController {
     // 좌석 수정 (어도민 권한)
     @PatchMapping("/{seatId}")
     @PreAuthorize("hasRole('ADMIN')")
+    @TrackUserActionAnnotation("좌석 수정")
         public ResponseEntity<ApiResponse> updateSeat(
                 @PathVariable Long seatId,
                 @RequestBody SeatRequest request) {
-    @TrackUserActionAnnotation("좌석 수정")
-    public ResponseEntity<ApiResponse> updateSeat(
-            @PathVariable Long seatId,
-            @RequestBody SeatRequest request) {
 
         SeatResponse updatedSeat = seatService.updateSeat(seatId, request);
         return ResponseEntity.ok(ApiResponse.success(updatedSeat, "좌석 수정 성공"));

--- a/src/main/java/com/example/filmpass/domain/seat/controller/SeatController.java
+++ b/src/main/java/com/example/filmpass/domain/seat/controller/SeatController.java
@@ -4,6 +4,7 @@ import com.example.filmpass.domain.seat.dto.PagedResponse;
 import com.example.filmpass.domain.seat.dto.SeatRequest;
 import com.example.filmpass.domain.seat.dto.SeatResponse;
 import com.example.filmpass.domain.seat.service.SeatService;
+import com.example.filmpass.global.aop.TrackUserActionAnnotation;
 import com.example.filmpass.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -24,6 +25,7 @@ public class SeatController {
 
     // 좌석 등록 (상영관 연관관계, 어도민 권한)
     @PostMapping
+    @TrackUserActionAnnotation("좌석 등록")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse> createSeat(@RequestBody SeatRequest request) {
         SeatResponse createdSeat = seatService.createSeat(request);
@@ -47,6 +49,7 @@ public class SeatController {
 
     // 좌석 수정 (어도민 권한)
     @PreAuthorize("hasRole('ADMIN')")
+    @TrackUserActionAnnotation("좌석 수정")
     public ResponseEntity<ApiResponse> updateSeat(
             @PathVariable Long seatId,
             @RequestBody SeatRequest request) {

--- a/src/main/java/com/example/filmpass/domain/theater/controller/TheaterController.java
+++ b/src/main/java/com/example/filmpass/domain/theater/controller/TheaterController.java
@@ -29,7 +29,6 @@ public class TheaterController {
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     @TrackUserActionAnnotation("극장 등록")
-    public ResponseEntity<ApiResponse> createTheater(@RequestBody TheaterRequest request) {
     public ResponseEntity<ApiResponse> createTheater(@Valid @RequestBody TheaterRequest request) {
         TheaterResponse response = theaterService.createTheater(request);
         return ResponseEntity.ok(ApiResponse.success(response, "좌석 등록 성공"));

--- a/src/main/java/com/example/filmpass/domain/theater/controller/TheaterController.java
+++ b/src/main/java/com/example/filmpass/domain/theater/controller/TheaterController.java
@@ -2,6 +2,7 @@ package com.example.filmpass.domain.theater.controller;
 
 import com.example.filmpass.domain.theater.dto.TheaterResponse;
 import com.example.filmpass.domain.theater.service.TheaterService;
+import com.example.filmpass.global.aop.TrackUserActionAnnotation;
 import com.example.filmpass.global.common.ApiResponse;
 import com.example.filmpass.domain.theater.dto.PagedResponse;
 import com.example.filmpass.domain.theater.dto.TheaterRequest;
@@ -26,6 +27,7 @@ public class TheaterController {
     // 극장 등록 (어드민 권한)
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
+    @TrackUserActionAnnotation("극장 등록")
     public ResponseEntity<ApiResponse> createTheater(@RequestBody TheaterRequest request) {
         TheaterResponse response = theaterService.createTheater(request);
         return ResponseEntity.ok(ApiResponse.success(response, "좌석 등록 성공"));
@@ -49,6 +51,7 @@ public class TheaterController {
     // 극장 수정
     @PatchMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
+    @TrackUserActionAnnotation("극장 수정")
     public ResponseEntity<ApiResponse> updateTheater(
             @PathVariable Long id,
             @RequestBody TheaterRequest request) {

--- a/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/filmpass/domain/user/controller/UserController.java
@@ -3,6 +3,7 @@ package com.example.filmpass.domain.user.controller;
 import com.example.filmpass.domain.user.dto.PasswordRequestDto;
 import com.example.filmpass.domain.user.dto.UserInfoChangeRequestDto;
 import com.example.filmpass.domain.user.service.UserService;
+import com.example.filmpass.global.aop.TrackUserActionAnnotation;
 import com.example.filmpass.global.common.ApiResponse;
 import com.example.filmpass.global.config.UserPrincipal;
 import jakarta.validation.Valid;
@@ -32,6 +33,7 @@ public class UserController {
 
     // 유저 목록 조회
     @GetMapping("/api/users")
+    @TrackUserActionAnnotation("유저 목록 조회")
     public ApiResponse getUsers(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
@@ -44,6 +46,7 @@ public class UserController {
 
     // 유저 단건 조회
     @GetMapping("/api/users/{id}")
+    @TrackUserActionAnnotation("유저 단건 조회")
     public ApiResponse getUser(
         @PathVariable Long id,
         @AuthenticationPrincipal UserPrincipal principal

--- a/src/main/java/com/example/filmpass/global/aop/TrackUserActionAnnotation.java
+++ b/src/main/java/com/example/filmpass/global/aop/TrackUserActionAnnotation.java
@@ -1,0 +1,14 @@
+package com.example.filmpass.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TrackUserActionAnnotation {
+
+    String value() default "";
+
+}

--- a/src/main/java/com/example/filmpass/global/aop/UserActionLogger.java
+++ b/src/main/java/com/example/filmpass/global/aop/UserActionLogger.java
@@ -1,0 +1,51 @@
+package com.example.filmpass.global.aop;
+
+import com.example.filmpass.global.config.UserPrincipal;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@Slf4j
+public class UserActionLogger {
+
+    @Around("@annotation(trackUserActionAnnotation)")
+    public Object logUserAction(ProceedingJoinPoint joinPoint, TrackUserActionAnnotation trackUserActionAnnotation) throws Throwable {
+
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        // 로그에 나타낼 정보
+        String actionName = trackUserActionAnnotation.value();
+        String userIp = request.getRemoteAddr();
+        String methodName = joinPoint.getSignature().toShortString();
+
+        // 인증이 된 사용자가 아니면 익명값 할당
+        String userId = "anonymous";
+        String nickname = "anonymous";
+        String userRole = "unknown";
+
+        // 로그에 나타낼 유저의 정보를 SecurityContextHolder 에서 꺼내서 로그에 나타냄.
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+        if(principal instanceof UserPrincipal userPrincipal) {
+
+            userId = String.valueOf(userPrincipal.getUserId());
+            nickname = userPrincipal.getNickname();
+            userRole = userPrincipal.getUserRole().name();
+
+        }
+
+        log.warn("[사용자 행동] userId={}, nickname={}, role={}, action={}, method={}, ip={}",
+                userId, nickname, userRole, actionName, methodName, userIp);
+
+        return joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/com/example/filmpass/global/config/JwtFilter.java
+++ b/src/main/java/com/example/filmpass/global/config/JwtFilter.java
@@ -33,8 +33,8 @@ public class JwtFilter extends OncePerRequestFilter {
         String bearerJwt = request.getHeader("Authorization");
 
         if(bearerJwt == null || !bearerJwt.startsWith("Bearer")) {
+            log.error("JWT 필터에서 예외 발생 - 토큰이 없음.");
             filterChain.doFilter(request, response);
-            return;
         }
 
         // bear 제거
@@ -62,7 +62,12 @@ public class JwtFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authenticationToken);
 
         } catch (JwtException | IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.WRONG_TOKEN);
+            log.error("JWT 필터에서 예외 발생 - 잘못된 토큰값 입력");
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.setCharacterEncoding("UTF-8");
+            response.setContentType("application/json; charset=UTF-8");
+            response.getWriter().write("{\"message\": \"잘못된 JWT 토큰입니다.\"}");
+            return;
         }
 
         filterChain.doFilter(request, response);


### PR DESCRIPTION
feat

UserController, TheaterController, AuthController, SearController
  - 관리자 기능 사용시 로그를 추적하도록 커스텀 어노테이션 등록
 
TrackUserActionAnnotation
  - 커스텀 어노테이션 생성
 
UserActionLogger
  - 커스텀 어노테이션의 로직 작성
     - 추적 항목 : user_id, nickname, role, API 기능 이름, 호출한 메서드 이름, 사용자 ip


fix

JwtFilter
  - 토큰이 빈값이면 로그를 남기도록 수정
  - 토큰이 잘못된 값이면 400 을 반환 및 로그를 남기도록 수정


closes #144 